### PR TITLE
Fix Google SAML compatibility

### DIFF
--- a/redash/authentication/saml_auth.py
+++ b/redash/authentication/saml_auth.py
@@ -79,8 +79,14 @@ def idp_initiated(org_slug=None):
     authn_response.get_identity()
     user_info = authn_response.get_subject()
     email = user_info.text
-    name = "%s %s" % (authn_response.ava['FirstName'][0], authn_response.ava['LastName'][0])
-
+    # Google SAML auth does not return these FirstName / LastName fields
+    try:
+        name = "%s %s" % (authn_response.ava['FirstName'][0], authn_response.ava['LastName'][0])
+    except Exception as e:
+        #logger.exception(e)
+        logger.warning("could not fetch FirstName or LastName from SAML response: falling back to email user")
+        name = email.split('@')[0]
+    
     # This is what as known as "Just In Time (JIT) provisioning".
     # What that means is that, if a user in a SAML assertion
     # isn't in the user store, we create that user first, then log them in


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

Two issues with the "supported" bitnami image on Azure when enabling Google SAML:

1. missing xmlsec1

Solution:

`apt-get install xmlsec1`

2. line 82 of /opt/bitnami/apps/redash/htdocs/redash/authentication/saml_auth.py
(`name = "%s %s" % (authn_response.ava['FirstName'][0], authn_response.ava['LastName'][0])`)
required the following patch to replace it:

```
    try:
        name = "%s %s" % (authn_response.ava['FirstName'][0], authn_response.ava['LastName'][0])
    except Exception as e:
        logger.exception(e)
        name = email.split('@')[0]
```


Prior to that patch, error upon hitting SAML Login was as follows:

```
[2019-12-05 01:54:40,607] ERROR in app: Exception on /saml/callback [POST]
Traceback (most recent call last):
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask_restful/__init__.py", line 271, in error_router
    return original_handler(e)
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
    rv = self.dispatch_request()
  File "/opt/bitnami/apps/redash/htdocs/venv/lib/python2.7/site-packages/flask/app.py", line 1598, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/opt/bitnami/apps/redash/htdocs/redash/authentication/saml_auth.py", line 82, in idp_initiated
    name = "%s %s" % (authn_response.ava['FirstName'][0], authn_response.ava['LastName'][0])
KeyError: 'FirstName'

```

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
